### PR TITLE
3.1.0 Update qbench (better runner, +supplemental code & CLI) + bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.1.0
+- **Enhance qbench benchmarking core**: Refactor `bench()` to support richer benchmark descriptions (argument generators, cache clearing, async wait hooks), configurable batching vs. per-iteration timing, randomization of function order, and etc.
+- **Add benchmark registration and CLI support**: Introduce `registerBenchmark`, `getRegisteredBenchmarkSetNames`, `getRegisteredBenchmarks`, and `makeArgumentParser()` so benchmark sets can be registered, selected by name, and run from a command-line interface with various options.
+- **Bugfix**: how benchmarks are matched one against the other: `poolBenchmarks()` now splits benchmark names using the longest common prefix instead of the shortest.
+- **Bugfix** `LoggingConsole.print()` so log level prefixes render with correct brackets.
+- **Add tests for qbench**: Introduce `tests/test_qbench.py` covering canonical bench result shapes, correct placement of `wait_arg_complete`, and `BenchmarkDescription` initialization and `from_iterable()` behavior.
+
+**Potentially breaking changes**:
+- To prevent mistakes, made `showBench()` and `benchmark()` now accept most of arguments at kwargs only.
+- `benchmark()` now returns a `(CompareStatsResult, results)` tuple instead of just the `CompareStatsResult`.
+
 # 3.0.0
 - Breaking change: API of qbench module now uses simplified pass-through arguments to configure
     benchmarking. Now it's possible to just write

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Benchmark comparison results (Brunner Munzel test, alpha=0.00100)
 │               │ [1.224m,1.230m,1.257m]   │ [1.274m,1.283m,1.320m]   │
 │               │ p=0.00000+(10 vs 10)     │ p=0.00000+(10 vs 10)     │
 └───────────────┴──────────────────────────┴──────────────────────────┘
->>> s = qb.showBench(r, ("c|A","c|B","c|C"), "|") # custom names
+>>> s = qb.showBench(r, bm_names=("c|A","c|B","c|C"), alt_delimiter="|") # custom names
 Benchmark comparison results (Brunner Munzel test, alpha=0.00100)
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃            ┃ min (means),             ┃ mean (means),            ┃
@@ -337,7 +337,7 @@ Benchmark comparison results (Brunner Munzel test, alpha=0.00100)
 └────────────┴──────────────────────────┴──────────────────────────┘
 >>> # benchmark 4 callables
 >>> r = qb.bench((lambda:time.sleep(0.001), lambda:time.sleep(0.00102), lambda:time.sleep(0.0012), lambda: time.sleep(0.00125)))
->>> s = qb.showBench(r,("A","B")) # compare first two as alternatives of A, and the last two as B
+>>> s = qb.showBench(r,bm_names=("A","B")) # compare first two as alternatives of A, and the last two as B
 Benchmark comparison results (Brunner Munzel test, alpha=0.00100)
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃            ┃ min (means),             ┃ mean (means),            ┃

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchstats"
-version = "3.0.0.post1"
+version = "3.1.0"
 description = "Statistical Testing for Benchmark Results Comparison"
 readme = "README.md"
 authors = [{ name = "Aleksei Rechinskii", email = "5dpea9nhd@mozmail.com" }]

--- a/src/benchstats/common.py
+++ b/src/benchstats/common.py
@@ -79,7 +79,7 @@ class LoggingConsole(rich.console.Console):
         else:
             sep = " "
             kwargs["sep"] = sep
-        return super().print(f"\[[{color}]{lvl:4s}[/{color}]]{sep}", *args, **kwargs)
+        return super().print(f"[[{color}]{lvl:4s}[/{color}]]{sep}", *args, **kwargs)
 
     def debug(self, *args, **kwargs):
         if self.log_level > LoggingConsole.LogLevel.Debug:

--- a/src/benchstats/compare.py
+++ b/src/benchstats/compare.py
@@ -104,10 +104,11 @@ def poolBenchmarks(
     sg1: dict[str, dict[str, Iterable[float]]] | None,
     logger: LoggingConsole | None = None,
 ) -> dict[str, dict[str, dict[str, Iterable[float]]]]:
-    """Using the specified delimiter dividing the benchmark name into a common part and an
-    alternative name part, merges the benchmarks from one or two sets of benchmarks into a single
-    pool represented by a dictionary where a key specifies common part of benchmark name and a value
-    is a dict mapping from alternative name to a dictionary of metric names and their values.
+    """Using the specified delimiter divides each benchmark name into (the longest possible) common
+    part and an alternative name part, merges the benchmarks from one or two sets of benchmarks into
+    a single pool represented by a dictionary where a key specifies common part of benchmark name
+    and a value is a dict mapping from alternative name to a dictionary of metric names and their
+    values.
 
     If a benchmark name doesn't contain the delimiter, then its common name is assumed to be a whole
     benchmark name, and its alternative name is assumed to either "0" or "1" depending on the
@@ -123,7 +124,7 @@ def poolBenchmarks(
     def splitName(bm_name: str, pfx: str) -> tuple[str, str]:
         """Splits the benchmark name into a common part and an alternative part"""
         assert isinstance(bm_name, str)
-        s = bm_name.split(sep=alt_delimiter, maxsplit=1)
+        s = bm_name.rsplit(sep=alt_delimiter, maxsplit=1)
         if len(s) > 1:
             alt_name = s[1].strip()
             return s[0].strip(), pfx + (

--- a/src/benchstats/qbench.py
+++ b/src/benchstats/qbench.py
@@ -3,65 +3,270 @@ qbench is a separate benchstats module designed to alleviate benchmarking and be
 of Python callables.
 """
 
-import time
-import numpy as np
+import argparse
+from collections import namedtuple
+from collections.abc import Callable, Iterable
 import itertools
 import inspect
+import numpy as np
 from rich.progress import Progress
+from time import perf_counter_ns
+from typing import Any
 
 from benchstats.compare import compareStats, CompareStatsResult
 from benchstats.render import renderComparisonResults
 from benchstats.common import LoggingConsole
 
 
+def _getOptionalArgs(func) -> dict[str, Any]:
+    """Returns a dict of argument names of the function that have default values"""
+    s = inspect.getfullargspec(func)
+    kdefs = {}
+    if s.defaults:
+        def_ofs = len(s.args) - len(s.defaults)
+        for i in range(len(s.defaults)):
+            kdefs[s.args[def_ofs + i]] = s.defaults[i]
+    if s.kwonlydefaults:
+        kdefs.update(s.kwonlydefaults)
+
+    return kdefs
+
+
 # support for combined arguments of showBench()
-_g_compareStats_args = None
-_g_renderComparisonResults_args = None
-_g_joint_args = None
+_g_compareStats_args = frozenset(_getOptionalArgs(compareStats).keys())
+_g_renderComparisonResults_args = frozenset(_getOptionalArgs(renderComparisonResults).keys())
+_g_joint_args = _g_compareStats_args.intersection(_g_renderComparisonResults_args)
 
 
-def _getOptionalArgs(func):
-    arg_spec = inspect.getfullargspec(func)
-    return frozenset(arg_spec[0][len(arg_spec[0]) - len(arg_spec[3]) :])
+################################################################################
+# core benchmark runners
+################################################################################
 
 
-if _g_compareStats_args is None:
-    _g_compareStats_args = _getOptionalArgs(compareStats)
-    _g_renderComparisonResults_args = _getOptionalArgs(renderComparisonResults)
-    _g_joint_args = _g_compareStats_args.intersection(_g_renderComparisonResults_args)
+class BenchmarkDescription(
+    namedtuple(
+        "BenchmarkDescription",
+        ["bench_func", "args_func", "clear_cache_func", "wait_arg_complete", "wait_func_complete"],
+    )
+):
+    """Describes a benchmark, i.e. which function to measure, how to get its arguments, how to
+    respect asynchronicity, how to clear caches & etc.
+    Note that
+    """
+
+    __slots__ = ()
+    _max_len = 5
+    _n_posargs = 3
+
+    def __new__(
+        cls,
+        bench_func: Callable,
+        args_func: Callable[[], Iterable] | None = None,
+        clear_cache_func: Callable[[Iterable], None] | None = None,
+        *,
+        wait_complete: Callable[[Any], Any] | None = None,  # sets the default value for the 2 below
+        wait_arg_complete: Callable[[Any], Any] | None = None,
+        wait_func_complete: Callable[[Any], Any] | None = None,
+    ):
+        """Constructor to verify initialization correctness"""
+        assert callable(bench_func)
+        assert args_func is None or callable(args_func)
+        assert clear_cache_func is None or callable(clear_cache_func)
+        assert wait_complete is None or callable(wait_complete)
+        assert wait_arg_complete is None or callable(wait_arg_complete)
+        assert wait_func_complete is None or callable(wait_func_complete)
+
+        if wait_complete:
+            if wait_arg_complete is None:
+                wait_arg_complete = wait_complete
+            if wait_func_complete is None:
+                wait_func_complete = wait_complete
+
+        assert len(cls._fields) == cls._max_len
+        assert cls._max_len - cls._n_posargs == 2
+        return super().__new__(
+            cls, bench_func, args_func, clear_cache_func, wait_arg_complete, wait_func_complete
+        )
+
+    @classmethod
+    def _toArgsKwargs(
+        cls,
+        it,
+        def_args_func: Callable[[], Iterable],
+        def_wait_arg_complete: Callable[[Any], Any],
+        def_wait_func_complete: Callable[[Any], Any],
+        def_clear_cache: Callable[[Iterable], None],
+    ):
+        it_len = len(it)
+        assert it_len <= cls._max_len
+
+        args = [a for a in it[: cls._n_posargs]]
+        if len(args) >= 2:
+            if args[1] is None:
+                args[1] = def_args_func
+        else:
+            args.append(def_args_func)
+
+        if len(args) >= 3:
+            if args[2] is None:
+                args[2] = def_clear_cache
+        else:
+            args.append(def_clear_cache)
+
+        assert len(args) == cls._n_posargs and all(callable(f) for f in args)
+
+        def _extractDefault(idx, def_val):
+            v = it[idx] if it_len >= cls._n_posargs else None
+            return def_val if v is None else v
+
+        kwargs = {
+            "wait_arg_complete": _extractDefault(cls._n_posargs, def_wait_arg_complete),
+            "wait_func_complete": _extractDefault(cls._n_posargs + 1, def_wait_func_complete),
+        }
+        assert len(kwargs) == cls._max_len - cls._n_posargs
+        assert all(callable(f) for f in kwargs.values())
+        return args, kwargs
+
+    @classmethod
+    def from_iterable(
+        cls,
+        it: Iterable,
+        def_args_func: Callable[[], Iterable] | None = None,
+        def_wait_arg_complete: Callable[[Any], Any] | None = None,
+        def_wait_func_complete: Callable[[Any], Any] | None = None,
+        def_clear_cache: Callable[[Iterable], None] | None = None,
+    ):
+        if def_args_func is None:
+            def_args_func = lambda: tuple()  # noqa: E731
+        def_wait_complete = lambda x: x  # noqa: E731
+        if def_wait_arg_complete is None:
+            def_wait_arg_complete = def_wait_complete
+        if def_wait_func_complete is None:
+            def_wait_func_complete = def_wait_complete
+        if def_clear_cache is None:
+            def_clear_cache = lambda x: None  # noqa: E731
+
+        args, kwargs = cls._toArgsKwargs(
+            it, def_args_func, def_wait_arg_complete, def_wait_func_complete, def_clear_cache
+        )
+        return cls(*args, **kwargs)
+
+
+def _toBenchmarkDescription(
+    funcs: Iterable | Callable,
+    def_wait_arg_complete: Callable[[Any], Any] | None,
+    def_wait_func_complete: Callable[[Any], Any] | None,
+    def_clear_cache: Callable[[Iterable], None] | None,
+) -> list[BenchmarkDescription]:
+    """Transforms `funcs` argument of `bench()` function to a canonical list of BenchmarkDescription
+    objects"""
+    if not isinstance(funcs, Iterable):
+        assert callable(funcs)
+        funcs = (funcs,)
+
+    assert len(funcs) > 0
+    def_args_func = lambda: tuple()  # noqa: E731
+    ret = []
+
+    for e in funcs:
+        if callable(e):
+            # important to use from_iterable() to inject defaults
+            ret.append(BenchmarkDescription.from_iterable((e, def_args_func)))
+        else:
+            ret.append(
+                BenchmarkDescription.from_iterable(
+                    e,
+                    def_args_func,
+                    def_wait_arg_complete,
+                    def_wait_func_complete,
+                    def_clear_cache,
+                )
+            )
+
+    return ret
 
 
 def bench(
-    funcs: tuple | list,
+    funcs: Iterable | Callable,
+    *,
     iters: int = 100,
     reps: int = 10,
-    warmup: int = 0,
-    show_progress: bool = True,
+    warmup: int = 5,
+    batch_functions: bool = False,
+    randomize_iterations: bool = True,
+    wait_complete: None | Callable[[Any], Any] = None,  # lambda x: x
+    wait_arg_complete: None | Callable[[Any], Any] = None,
+    wait_func_complete: None | Callable[[Any], Any] = None,
+    clear_cache: None | Callable[[Iterable], None] = None,  # lambda x: None,
+    show_progress_each: int = 1,
 ) -> np.ndarray:
     """
     Benchmarks the provided callables by measuring their runtimes over multiple iterations and repetitions.
 
-    Args:
-        funcs (tuple|list|callable): A tuple of callables, each callable must be invocable without
-            arguments; Or a single callable to benchmark.
-        iters (int, optional): Number of iterations per repetition. Defaults to 100.
-        reps (int, optional): Number of repetitions. Defaults to 10.
-        warmup (int, optional): Number of warmup iterations. Warmups are useful for letting the
-            system to converge to a stable state. Also are mandatory for a certain code, such as
-            jit-compiled functions from JAX. Defaults to 0.
+    Arguments:
+    - funcs (Iterable): A single callable, or an iterable describing callables to benchmark.
+        In the latter case, each element could contain either:
+        - a callable that could be used without arguments, or
+        - an iterable containing `BenchmarkDescription` tuple or 1-3 callables:
+            (bench_func, args_func, clear_cache_func), where args_func is function of 0 arguments
+            returning a tuple or a list of arguments to pass to the bench_func, and clear_cache_func
+            is a function taking an iterable returned from args_func() and doing all the necessary
+            cache clearing.
+    - iters (int, optional): Number of iterations per repetition. Defaults to 100.
+    - reps (int, optional): Number of repetitions. Defaults to 10.
+    - warmup (int, optional): Number of warmup iterations. Warmups are useful for letting the
+        system to converge to a stable state. Also are mandatory for a certain code, such as
+        jit-compiled functions from JAX. Defaults to 1.
+    - batch_functions (bool, optional): controls how two inner-most benchmarking loops are
+        organized. When False (the default), we first launch iteration loop, then loop over the
+        functions: `for i in range(iters): for f in range(len(funcs)): do_benchmark(f)`. When
+        True, it's reversed: `for f in range(len(funcs)): for i in range(iters): do_benchmark(f)`.
+        The latter variant due to a strong hardware caches effect is only useful, when the function
+        is going to be called in a tight loop, otherwise results will be more skewed.
+    - randomize_iterations (bool, optional) Especially when batch_functions==False measuring timings
+        of the same code in a predefined order might skewed results due to hardware caching effects.
+        Setting this to True will ensure that each function will be called in a random order within
+        an iteration. Defaults to True. Don't set to False unless len(funcs) >> 10.
+    - wait_complete (Callable, optional): benchmarking asynchronous functions require awaiting for
+        completion of their execution. wait_complete() is a function accepts a return value of
+        bench_func() function to benchmark and returns when it's ready. If `wait_arg_complete`
+        is None and `funcs` are used with args_func, - wait_arg_complete <- wait_complete
+    - wait_arg_complete and wait_func_complete allow to set separate awaiting functions for
+        args_func and bench_func. Note that wait_arg_complete is applied to each element of
+        iterable that args_func() returns.
+    - clear_cache (Callable, optional) - a function taking an iterable that an args_func could
+        return, and performing all necessary HW & other cache clearing necessary. Return value is
+        ignored. This parameter sets a default `clear_cache_func` for each of `funcs` if
+        `clear_cache_func` isn't provided
+    - show_progress_each - if an positive integer, will show progress bars and update each that
+        number of iterations
 
     Returns:
         np.ndarray: A 3D numpy array of runtimes in seconds with shape (n_funcs, reps, iters). Or,
             if only one function is provided, a 2D array with shape (reps, iters).
     """
-    if not isinstance(funcs, (list, tuple)):
-        funcs = (funcs,)
-    if any(not callable(func) for func in funcs):
-        raise ValueError("All elements in funcs must be callable.")
+    show_progress = isinstance(show_progress_each, int) and show_progress_each > 0
+
+    @staticmethod
+    def _time_execution(bd: BenchmarkDescription) -> float:
+        args = bd.args_func()
+        assert isinstance(args, Iterable)
+        # it's super important to materialize genexpr here, or it'll be timed!
+        inputs = tuple(bd.wait_arg_complete(a) for a in args)
+
+        start = perf_counter_ns()
+        o = bd.wait_func_complete(bd.bench_func(*inputs))
+        end = perf_counter_ns()
+        return (end - start) * 1e-9
+
+    if wait_arg_complete is None:
+        wait_arg_complete = wait_complete
+    if wait_func_complete is None:
+        wait_func_complete = wait_complete
+
+    funcs = _toBenchmarkDescription(funcs, wait_arg_complete, wait_func_complete, clear_cache)
 
     n_funcs = len(funcs)
-    if n_funcs == 0:
-        raise ValueError("funcs must be a tuple with at least one callable.")
     assert iters > 0, "iters must be a positive integer."
     assert reps > 0, "reps must be a positive integer."
     assert warmup >= 0, "reps must be a non-negative integer."
@@ -69,7 +274,10 @@ def bench(
     if show_progress:
         progress = Progress(transient=True)
         warmup_task = progress.add_task("Warmup", total=warmup)
-        iter_task = progress.add_task("Iterations", total=iters)
+        if batch_functions:
+            func_task = progress.add_task("Functions", total=n_funcs)
+        else:
+            iter_task = progress.add_task("Iterations", total=iters)
         reps_task = progress.add_task("Repetitions", total=reps)
         rwarmup = progress.track(range(warmup), task_id=warmup_task)
         rreps = progress.track(range(reps), task_id=reps_task)
@@ -78,26 +286,37 @@ def bench(
         rreps = range(reps)
         rwarmup = range(warmup)
 
-    for w in rwarmup:
-        for f in funcs:
-            f()
+    for f in funcs:
+        for _ in rwarmup:
+            _time_execution(f)
 
     if show_progress:
         progress.update(warmup_task, visible=False)
 
     results = np.empty((n_funcs, reps, iters), dtype=np.float64)
+    bm_idxs = np.arange(n_funcs, dtype=np.int32)
+    rng = np.random.default_rng()
 
     for r in rreps:
         if show_progress:
-            progress.update(iter_task, completed=0)
-        for i in range(iters):
-            for f_idx, func in enumerate(funcs):
-                start = time.perf_counter_ns()
-                func()
-                end = time.perf_counter_ns()
-                results[f_idx, r, i] = (end - start) * 1e-9  # convert ns to seconds
-            if show_progress:
-                progress.update(iter_task, completed=i)
+            progress.update(func_task if batch_functions else iter_task, completed=0)
+
+        if batch_functions:
+            if randomize_iterations:
+                rng.shuffle(bm_idxs)
+            for fi, f_idx in enumerate(bm_idxs):
+                for i in range(iters):
+                    results[f_idx, r, i] = _time_execution(funcs[f_idx])
+                if show_progress and fi % show_progress_each == 0:
+                    progress.update(func_task, completed=fi)
+        else:
+            for i in range(iters):
+                if randomize_iterations:
+                    rng.shuffle(bm_idxs)
+                for f_idx in bm_idxs:
+                    results[f_idx, r, i] = _time_execution(funcs[f_idx])
+                if show_progress and i % show_progress_each == 0:
+                    progress.update(iter_task, completed=i)
 
     if show_progress:
         progress.stop()
@@ -129,6 +348,7 @@ def bench2(func1, func2, **kwargs):
 
 def showBench(
     results: np.ndarray,
+    *,
     bm_names: tuple | list | str = "code",
     alt_delimiter: str | None = None,
     metrics: dict = {"min": np.min, "mean": np.mean},
@@ -139,34 +359,36 @@ def showBench(
     Displays the benchmark results in a human-readable format.
 
     Args:
-        results (np.ndarray): The benchmark results as a 3D or 2D numpy array. Essentially, the
-            output of the bench() function.
-            If a 2D array is provided (only a single function was benchmarked), then a fake
-            comparison against itself is performed (essentially, it's just a performance report of
-            the function). In that case `alt_delimiter` parameter must be None.
-        bm_names (tuple|list|str, optional) and alt_delimiter: (str|None, optional): defines the
-            names of the benchmarks and how they are compared one against the other. Options are:
-            - if alt_delimiter is None:
-                - if bm_names is a single string, then all results are assumed to be from
-                    alternatives of the same code, and are all compared one against the other, using
-                    numeric indices as alternative names.
-                - if bm_names is a tuple or list of strings, of length that is an exact divisor of
-                    the number of functions benchmarked. There must be more results than names.
-                    The first set of functions are assumed to be different alternatives of a single
-                    code with the first name, the second set of functions are assumed to be
-                    different alternatives of the second set of functions with the second name, and
-                    so on. Numeric indices are used as alternative names.
-            - if alt_delimiter is a string:
-                - bm_names must be a tuple or list of strings with the same length as the number
-                    of functions benchmarked (results.shape[0]), where each string is parsed
-                    according to the expected format:
-                    "<common_name>{alt_delimiter}<alternative_name>".
-        metrics (dict[str, callable], optional): A description of metrics functions used to
-            aggregate data from individual benchmark iterations.
-        kwCompareStats_and_renderArgs: Any optional arguments of the compareStats()
-            or renderComparisonResults() functions. By default compareStats() also gets
-            store_sets=True argument, and renderComparisonResults() gets
-            show_sample_sizes=True and sample_stats=("extremums", "median") arguments.
+    - results (np.ndarray): The benchmark results as a 3D or 2D numpy array. Essentially, the
+        output of the bench() function.
+        If a 2D array is provided (only a single function was benchmarked), then a fake
+        comparison against itself is performed (essentially, it's just a performance report of
+        the function). In that case `alt_delimiter` parameter must be None.
+    - bm_names (tuple|list|str, optional) and alt_delimiter: (str|None, optional): defines the
+        names of the benchmarks and how they are compared one against the other. Options are:
+        - if alt_delimiter is None:
+            - if bm_names is a single string, then all results are assumed to be from
+                alternatives of the same code, and are all compared one against the other, using
+                numeric indices as alternative names.
+            - if bm_names is a tuple or list of strings, of length that is an exact divisor of
+                the number of functions benchmarked. There must be more results than names.
+                The first set of functions are assumed to be different alternatives of a single
+                code with the first name, the second set of functions are assumed to be
+                different alternatives of the second set of functions with the second name, and
+                so on. Numeric indices are used as alternative names.
+        - if alt_delimiter is a string:
+            - bm_names must be a tuple or list of strings with the same length as the number
+                of functions benchmarked (results.shape[0]), where each string is parsed
+                according to the expected format: "<common_name>{alt_delimiter}<alternative_name>".
+                Benchmarks with the same "<common_name>" are compared pairwise.
+    - metrics (dict[str, callable], optional): A description of metrics functions used to
+        aggregate data from individual benchmark iterations.
+    - kwCompareStats_and_renderArgs: Any optional arguments of the compareStats()
+        or renderComparisonResults() functions. By default compareStats() also gets
+        store_sets=True argument, and renderComparisonResults() gets
+        show_sample_sizes=True and sample_stats=("extremums", "median") arguments.
+
+    Returns: CompareStatsResult object with comparison results
     """
     if results.ndim == 2:
         results = np.expand_dims(results, axis=0)
@@ -260,14 +482,13 @@ def showBench(
     return sr
 
 
-_g_bench_args = None
-_g_showBench_args = None
-if _g_bench_args is None:
-    _g_bench_args = _getOptionalArgs(bench)
-    _g_showBench_args = _getOptionalArgs(showBench)
+_g_bench_defaults = _getOptionalArgs(bench)
+_g_bench_args = frozenset(_g_bench_defaults.keys())
+_g_showBench_args = frozenset(_getOptionalArgs(showBench).keys())
+assert not (_g_bench_args & _g_showBench_args)
 
 
-def benchmark(funcs: tuple | list, **kwargs):
+def benchmark(funcs: tuple | list, **kwargs) -> tuple[CompareStatsResult, np.ndarray]:
     """
     Benchmarks the provided callables and displays the results.
     Args:
@@ -275,6 +496,7 @@ def benchmark(funcs: tuple | list, **kwargs):
             arguments; Or a single callable to benchmark.
         **kwargs: Additional keyword arguments for the bench() and showBench() functions, as well as
             optional arguments for compareStats() and renderComparisonResults() functions.
+    Returns: CompareStatsResult of the comparison and raw measured latencies as np.ndarray
     """
     bench_args = {}
     show_args = {}
@@ -288,4 +510,139 @@ def benchmark(funcs: tuple | list, **kwargs):
             compare_and_render_args[k] = v
 
     results = bench(funcs, **bench_args)
-    return showBench(results, **show_args, **compare_and_render_args)
+    return showBench(results, **show_args, **compare_and_render_args), results
+
+
+################################################################################
+# benchmark registration & run support
+################################################################################
+
+# a global object to store registered benchmark generating functions.
+# For more info see registerBenchmark()
+benchmark_sets: dict[str, Callable] = {}
+
+
+def registerBenchmark(f: Callable) -> Callable:
+    """A function decorator to register a function as a benchmark generating function.
+
+    A benchmark generating function `f` is a function of 0 parameters returning a dictionary mapping
+    a benchmark name to an argument-less callable, or an iterable of 2 callables -
+    (args_func, bench_func), where args_func is a function of 0 arguments returning a tuple or a
+    list of arguments to pass to the bench_func. Name of `f` must adhere to
+    `make_<bmset_name>_benchmark` convention, i.e. start with `make_` and on `_benchmark` strings,
+    where the middle part defines a name of the benchmarks set.
+
+    Each individual benchmark name in the returned by `f` dictionary must be unique across all
+    benchmark sets going to be registered.
+    """
+    global benchmark_sets
+
+    name_parts = f.__name__.split("_", maxsplit=-1)
+    assert len(name_parts) >= 3
+    assert name_parts[0] == "make" and name_parts[-1] == "benchmark"
+    name = name_parts[1:-1]
+    benchmark_sets["_".join(name)] = f
+    return f
+
+
+def getRegisteredBenchmarkSetNames() -> tuple[str, ...]:
+    """Returns all benchmark set names registered so far"""
+    return tuple(benchmark_sets.keys())
+
+
+def getRegisteredBenchmarks(enabled: None | str | Iterable[str] = None) -> dict:
+    """Finds benchmark sets matching the enabled, executes their generating functions and returns
+    all obtained individual benchmarks from that, ready to call .bench()"""
+    if not enabled:
+        enabled = getRegisteredBenchmarkSetNames()
+    if isinstance(enabled, str):
+        enabled = (enabled,)
+
+    bms = {}
+    for bm_id in enabled:
+        if bm_id not in benchmark_sets:
+            raise ValueError(
+                f"Benchmark set {bm_id} not found, available benchmark sets are: {', '.join(benchmark_sets.keys())}"
+            )
+
+        b = benchmark_sets[bm_id]()
+        assert frozenset(b.keys()) not in bms, "Some benchmark ids are colliding!"
+        bms.update(b)
+    return bms
+
+
+################################################################################
+# CLI support
+################################################################################
+
+
+def makeArgumentParser(parser=None, *, allow_exports=True):
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            description="Benchmarks runner",
+        )
+
+    parser.add_argument(
+        "benchmark_sets",
+        nargs="*",
+        default=None,
+        help=f"Benchmark sets to run. Available: {', '.join(benchmark_sets.keys())}. Default: all.",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=_g_bench_defaults["iters"],
+        help=f"Iterations per repetition (default: {_g_bench_defaults['iters']})",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=_g_bench_defaults["reps"],
+        help=f"Number of repetitions (default: {_g_bench_defaults['reps']})",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=_g_bench_defaults["warmup"],
+        help=f"Number of warmup iterations (default: {_g_bench_defaults['warmup']})",
+    )
+    parser.add_argument(
+        "--batch_functions",
+        action=argparse.BooleanOptionalAction,
+        default=_g_bench_defaults["batch_functions"],
+        help="If true: outer loop - benchmarks, inner loop - iterations. Otherwise reversed: "
+        f"outer loop - iterations, inner loop - benchmarks. (default: {_g_bench_defaults['batch_functions']})",
+    )
+    parser.add_argument(
+        "--randomize_iterations",
+        action=argparse.BooleanOptionalAction,
+        default=_g_bench_defaults["randomize_iterations"],
+        help=f"Randomly shuffle benchmarks order (default: {_g_bench_defaults['randomize_iterations']})",
+    )
+
+    if allow_exports:
+        parser.add_argument(
+            "--export_path_pfx",
+            type=str,
+            default=None,
+            help="If set, specifies a filename prefix for exporting console output. See `--export_*` flags below ",
+        )
+        parser.add_argument(
+            "--export_svg",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="When --export_path_pfx is set, export console output to .svg file",
+        )
+        parser.add_argument(
+            "--export_txt",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="When --export_path_pfx is set, export console output to .txt file",
+        )
+        parser.add_argument(
+            "--export_results",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="When --export_path_pfx is set, export benchmark results tensor to .npy file",
+        )
+    return parser

--- a/tests/test_qbench.py
+++ b/tests/test_qbench.py
@@ -1,0 +1,82 @@
+import sys
+import unittest
+import numpy as np
+import pytest
+import time
+import traceback
+
+import benchstats.qbench as qb
+
+
+class TestBench(unittest.TestCase):
+    def test_canonical_form(self):
+        f1 = lambda: time.sleep(0.001)  # noqa : E731
+        f2 = lambda x: time.sleep(x)  # noqa : E731
+        r = qb.bench((f1, (f2, lambda: (0.01,))), iters=2, reps=1)
+        np.testing.assert_allclose(
+            r, np.array([[[0.001, 0.001]], [[0.01, 0.01]]]), rtol=0, atol=0.005
+        )
+
+    def test_wait_arg_complete(self):
+        def wait_arg_complete(x):
+            s = traceback.extract_stack()
+            self.assertGreater(len(s), 4)
+            # ensuring that wait_arg_complete() isn't called under benchmarks timing section
+            # (might happen if genexpr isn't instantiated previously)
+            self.assertNotIn("bench_func", s[-3].line)
+            return x
+
+        qb.bench(
+            ((lambda x: x, lambda: (1,)),),
+            iters=1,
+            reps=1,
+            warmup=0,
+            wait_arg_complete=wait_arg_complete,
+        )
+
+    def test_BenchmarkDescription(self):
+        # test initialization
+        BD = qb.BenchmarkDescription
+
+        def bench_func():
+            return 42
+
+        def wait_complete():
+            return 24
+
+        def _assertRaw(obj):
+            self.assertIs(obj.bench_func, bench_func)
+            self.assertIsNone(obj.args_func)
+            self.assertIsNone(obj.clear_cache_func)
+            self.assertIs(obj.wait_arg_complete, wait_complete)
+            self.assertIs(obj.wait_func_complete, wait_complete)
+
+        a = BD(bench_func, wait_complete=wait_complete)
+        _assertRaw(a)
+
+        # test from_iterable
+        def _assertFromIterable(obj, has_completes=True):
+            self.assertIs(obj.bench_func, bench_func)
+            self.assertIsNotNone(obj.args_func)
+            self.assertIsNotNone(obj.clear_cache_func)
+            if has_completes:
+                self.assertIs(obj.wait_arg_complete, wait_complete)
+                self.assertIs(obj.wait_func_complete, wait_complete)
+            else:
+                self.assertIsNotNone(obj.wait_arg_complete)
+                self.assertIsNotNone(obj.wait_func_complete)
+                
+        b = BD.from_iterable(a)
+        _assertFromIterable(b)
+        c = BD.from_iterable((bench_func,))
+        _assertFromIterable(c, False)
+        d = BD.from_iterable(
+            (bench_func,),
+            def_wait_arg_complete=wait_complete,
+            def_wait_func_complete=wait_complete,
+        )
+        _assertFromIterable(d)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
# 3.1.0
- **Enhance qbench benchmarking core**: Refactor `bench()` to support richer benchmark descriptions (argument generators, cache clearing, async wait hooks), configurable batching vs. per-iteration timing, randomization of function order, and etc.
- **Add benchmark registration and CLI support**: Introduce `registerBenchmark`, `getRegisteredBenchmarkSetNames`, `getRegisteredBenchmarks`, and `makeArgumentParser()` so benchmark sets can be registered, selected by name, and run from a command-line interface with various options.
- **Bugfix**: how benchmarks are matched one against the other: `poolBenchmarks()` now splits benchmark names using the longest common prefix instead of the shortest.
- **Bugfix** `LoggingConsole.print()` so log level prefixes render with correct brackets.
- **Add tests for qbench**: Introduce `tests/test_qbench.py` covering canonical bench result shapes, correct placement of `wait_arg_complete`, and `BenchmarkDescription` initialization and `from_iterable()` behavior.

**Potentially breaking changes**:
- To prevent mistakes, made `showBench()` and `benchmark()` now accept most of arguments at kwargs only.
- `benchmark()` now returns a `(CompareStatsResult, results)` tuple instead of just the `CompareStatsResult`.